### PR TITLE
Refine slot logic and add tests

### DIFF
--- a/__tests__/slotMachine.test.js
+++ b/__tests__/slotMachine.test.js
@@ -1,0 +1,220 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mountSlotMachine, formatNumber } from '../script.js';
+
+class MockElement {
+  constructor(id, doc) {
+    this.id = id;
+    this.ownerDocument = doc;
+    this.textContent = '';
+    this._children = [];
+    this.className = '';
+  }
+
+  get children() {
+    return this._children;
+  }
+
+  get lastElementChild() {
+    return this._children[this._children.length - 1] ?? null;
+  }
+
+  prepend(child) {
+    this._children.unshift(child);
+  }
+
+  removeChild(child) {
+    const index = this._children.indexOf(child);
+    if (index >= 0) {
+      this._children.splice(index, 1);
+    }
+  }
+
+  set innerHTML(value) {
+    if (value === '') {
+      this._children = [];
+      return;
+    }
+    throw new Error('MockElement.innerHTML only supports clearing content.');
+  }
+
+  addEventListener() {
+    // Event listeners are attached in production but invoked directly in tests.
+  }
+}
+
+class MockButton extends MockElement {
+  constructor(id, doc) {
+    super(id, doc);
+    this.listeners = new Map();
+  }
+
+  addEventListener(event, handler) {
+    this.listeners.set(event, handler);
+  }
+
+  click() {
+    const handler = this.listeners.get('click');
+    if (handler) {
+      handler();
+    }
+  }
+}
+
+class MockDocument {
+  constructor() {
+    this.elements = new Map();
+  }
+
+  registerElement(id, element) {
+    this.elements.set(id, element);
+  }
+
+  getElementById(id) {
+    return this.elements.get(id) ?? null;
+  }
+
+  createElement(tagName) {
+    return new MockElement(tagName, this);
+  }
+}
+
+function createTestDocument({ initialCredits = 50 } = {}) {
+  const doc = new MockDocument();
+  const creditDisplay = new MockElement('credit-display', doc);
+  const betDisplay = new MockElement('bet-display', doc);
+  const eventLog = new MockElement('event-log', doc);
+  const betButton = new MockButton('bet-button', doc);
+  const spinButton = new MockButton('spin-button', doc);
+  const resetButton = new MockButton('reset-button', doc);
+
+  doc.registerElement('credit-display', creditDisplay);
+  doc.registerElement('bet-display', betDisplay);
+  doc.registerElement('event-log', eventLog);
+  doc.registerElement('bet-button', betButton);
+  doc.registerElement('spin-button', spinButton);
+  doc.registerElement('reset-button', resetButton);
+
+  return {
+    doc,
+    elements: {
+      creditDisplay,
+      betDisplay,
+      eventLog,
+      betButton,
+      spinButton,
+      resetButton,
+    },
+    initialCredits,
+  };
+}
+
+function latestLogText(eventLog) {
+  return eventLog.children[0]?.textContent ?? '';
+}
+
+test('formatNumber pads values with leading zeros', () => {
+  assert.equal(formatNumber(7), '007');
+  assert.equal(formatNumber(42, 4), '0042');
+});
+
+test('mountSlotMachine initialises displays and startup log', () => {
+  const { doc, elements } = createTestDocument();
+  const machine = mountSlotMachine(doc, {
+    timestampProvider: () => new Date('2023-01-01T00:00:00Z'),
+  });
+
+  assert.equal(elements.creditDisplay.textContent, '050');
+  assert.equal(elements.betDisplay.textContent, '00');
+  assert.equal(elements.eventLog.children.length, 1);
+  assert.ok(latestLogText(elements.eventLog).includes('スロット基盤を初期化しました。'));
+  assert.ok(machine);
+});
+
+test('handleBet increases bet until the configured maximum', () => {
+  const { doc, elements } = createTestDocument();
+  const machine = mountSlotMachine(doc, {
+    timestampProvider: () => new Date('2023-01-01T00:00:00Z'),
+  });
+
+  machine.handleBet();
+  machine.handleBet();
+  machine.handleBet();
+  machine.handleBet();
+
+  assert.equal(elements.betDisplay.textContent, '03');
+  assert.ok(latestLogText(elements.eventLog).includes('BETは最大値です。'));
+});
+
+test('handleBet blocks wagers that exceed available credits', () => {
+  const { doc, elements } = createTestDocument();
+  const machine = mountSlotMachine(doc, {
+    initialCredits: 2,
+    timestampProvider: () => new Date('2023-01-01T00:00:00Z'),
+  });
+
+  machine.handleBet();
+  machine.handleBet();
+  machine.handleBet();
+
+  assert.equal(elements.betDisplay.textContent, '02');
+  assert.ok(latestLogText(elements.eventLog).includes('クレジットが不足しています。'));
+});
+
+test('handleSpin consumes credits and resets bet', () => {
+  const { doc, elements } = createTestDocument();
+  const machine = mountSlotMachine(doc, {
+    timestampProvider: () => new Date('2023-01-01T00:00:00Z'),
+  });
+
+  machine.handleBet();
+  machine.handleBet();
+  machine.handleSpin();
+
+  assert.equal(elements.creditDisplay.textContent, '048');
+  assert.equal(elements.betDisplay.textContent, '00');
+  assert.ok(latestLogText(elements.eventLog).includes('BET: 02'));
+});
+
+test('handleSpin warns when no bet is set', () => {
+  const { doc, elements } = createTestDocument();
+  const machine = mountSlotMachine(doc, {
+    timestampProvider: () => new Date('2023-01-01T00:00:00Z'),
+  });
+
+  machine.handleSpin();
+
+  assert.ok(latestLogText(elements.eventLog).includes('BETが設定されていません。'));
+});
+
+test('handleReset restores the initial state and clears logs', () => {
+  const { doc, elements } = createTestDocument();
+  const machine = mountSlotMachine(doc, {
+    timestampProvider: () => new Date('2023-01-01T00:00:00Z'),
+  });
+
+  machine.handleBet();
+  machine.handleSpin();
+  machine.handleReset();
+
+  assert.equal(elements.creditDisplay.textContent, '050');
+  assert.equal(elements.betDisplay.textContent, '00');
+  assert.equal(elements.eventLog.children.length, 1);
+  assert.ok(latestLogText(elements.eventLog).includes('初期状態にリセットしました。'));
+});
+
+test('addLog trims the oldest entries when exceeding the limit', () => {
+  const { doc, elements } = createTestDocument();
+  const machine = mountSlotMachine(doc, {
+    maxLogItems: 3,
+    timestampProvider: () => new Date('2023-01-01T00:00:00Z'),
+  });
+
+  for (let i = 0; i < 5; i += 1) {
+    machine.addLog(`テストログ${i}`);
+  }
+
+  assert.equal(elements.eventLog.children.length, 3);
+  const oldest = elements.eventLog.children.at(-1);
+  assert.ok(oldest.textContent.includes('テストログ2'));
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>スロットシミュレーター</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <header class="app__header">
+        <h1 class="app__title">HTML/CSS/JS パチスロ</h1>
+        <p class="app__subtitle">基盤構造（仮）</p>
+      </header>
+
+      <section class="slot">
+        <div class="slot__reels" aria-label="スロットリール">
+          <div class="reel" data-reel="1">
+            <ul class="reel__window">
+              <li class="symbol">7</li>
+              <li class="symbol">BAR</li>
+              <li class="symbol">🍒</li>
+            </ul>
+          </div>
+          <div class="reel" data-reel="2">
+            <ul class="reel__window">
+              <li class="symbol">7</li>
+              <li class="symbol">BAR</li>
+              <li class="symbol">🍒</li>
+            </ul>
+          </div>
+          <div class="reel" data-reel="3">
+            <ul class="reel__window">
+              <li class="symbol">7</li>
+              <li class="symbol">BAR</li>
+              <li class="symbol">🍒</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="slot__panel">
+          <div class="panel__credits">
+            <span class="panel__label">クレジット</span>
+            <span class="panel__value" id="credit-display">000</span>
+          </div>
+          <div class="panel__bet">
+            <span class="panel__label">BET</span>
+            <span class="panel__value" id="bet-display">00</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="controls" aria-label="操作ボタン">
+        <button class="button" id="bet-button">BET</button>
+        <button class="button" id="spin-button">SPIN</button>
+        <button class="button" id="reset-button">RESET</button>
+      </section>
+
+      <section class="log" aria-live="polite">
+        <h2 class="log__title">イベントログ</h2>
+        <ul class="log__list" id="event-log"></ul>
+      </section>
+    </main>
+
+    <script type="module" src="script.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "slot-sample",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,165 @@
+export const DEFAULT_CONFIG = {
+  initialCredits: 50,
+  maxBet: 3,
+  maxLogItems: 6,
+  timestampProvider: () => new Date(),
+};
+
+export function formatNumber(value, digits = 3) {
+  return value.toString().padStart(digits, '0');
+}
+
+function formatTimestamp(date) {
+  const targetDate = date instanceof Date ? date : new Date(date);
+  return targetDate.toLocaleTimeString('ja-JP', {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+export class SlotMachine {
+  constructor(elements, config = {}) {
+    const {
+      creditDisplay,
+      betDisplay,
+      eventLog,
+      betButton,
+      spinButton,
+      resetButton,
+    } = elements;
+
+    if (!creditDisplay || !betDisplay || !eventLog) {
+      throw new Error(
+        'SlotMachine requires creditDisplay, betDisplay, and eventLog elements.'
+      );
+    }
+
+    this.creditDisplay = creditDisplay;
+    this.betDisplay = betDisplay;
+    this.eventLog = eventLog;
+    this.betButton = betButton;
+    this.spinButton = spinButton;
+    this.resetButton = resetButton;
+
+    this.config = { ...DEFAULT_CONFIG, ...config };
+
+    this.credits = this.config.initialCredits;
+    this.bet = 0;
+
+    this.handleBet = this.handleBet.bind(this);
+    this.handleSpin = this.handleSpin.bind(this);
+    this.handleReset = this.handleReset.bind(this);
+  }
+
+  init() {
+    if (this.betButton) {
+      this.betButton.addEventListener('click', this.handleBet);
+    }
+
+    if (this.spinButton) {
+      this.spinButton.addEventListener('click', this.handleSpin);
+    }
+
+    if (this.resetButton) {
+      this.resetButton.addEventListener('click', this.handleReset);
+    }
+
+    this.updateDisplays();
+    this.addLog('スロット基盤を初期化しました。');
+    return this;
+  }
+
+  updateDisplays() {
+    this.creditDisplay.textContent = formatNumber(this.credits);
+    this.betDisplay.textContent = formatNumber(this.bet, 2);
+  }
+
+  addLog(message) {
+    const logItem = this.eventLog.ownerDocument.createElement('li');
+    logItem.className = 'log__item';
+
+    const timestamp = formatTimestamp(this.config.timestampProvider());
+    logItem.textContent = `[${timestamp}] ${message}`;
+    this.eventLog.prepend(logItem);
+
+    while (this.eventLog.children.length > this.config.maxLogItems) {
+      this.eventLog.removeChild(this.eventLog.lastElementChild);
+    }
+  }
+
+  handleBet() {
+    if (this.bet >= this.config.maxBet) {
+      this.addLog('BETは最大値です。');
+      return;
+    }
+
+    if (this.bet + 1 > this.credits) {
+      this.addLog('クレジットが不足しています。');
+      return;
+    }
+
+    this.bet += 1;
+    this.updateDisplays();
+    this.addLog(`BETが ${formatNumber(this.bet, 2)} に設定されました。`);
+  }
+
+  handleSpin() {
+    if (this.bet === 0) {
+      this.addLog('BETが設定されていません。');
+      return;
+    }
+
+    if (this.credits < this.bet) {
+      this.addLog('クレジットが不足しています。');
+      return;
+    }
+
+    const betUsed = this.bet;
+    this.credits -= betUsed;
+    this.bet = 0;
+    this.updateDisplays();
+    this.addLog(
+      `スピン開始！ BET: ${formatNumber(
+        betUsed,
+        2
+      )} / 残りクレジット: ${formatNumber(this.credits)}`
+    );
+  }
+
+  handleReset() {
+    this.credits = this.config.initialCredits;
+    this.bet = 0;
+    this.eventLog.innerHTML = '';
+    this.updateDisplays();
+    this.addLog('初期状態にリセットしました。');
+  }
+}
+
+export function mountSlotMachine(doc = document, config = {}) {
+  if (!doc) {
+    throw new Error('A document instance is required to mount the slot machine.');
+  }
+
+  const elements = {
+    creditDisplay: doc.getElementById('credit-display'),
+    betDisplay: doc.getElementById('bet-display'),
+    eventLog: doc.getElementById('event-log'),
+    betButton: doc.getElementById('bet-button'),
+    spinButton: doc.getElementById('spin-button'),
+    resetButton: doc.getElementById('reset-button'),
+  };
+
+  return new SlotMachine(elements, config).init();
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      mountSlotMachine(document);
+    });
+  } else {
+    mountSlotMachine(document);
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,205 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Noto Sans JP', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  background-color: #0e0e16;
+  color: #f4f6ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at top, #1c1f3d 0%, #05070f 65%);
+}
+
+.app {
+  width: min(960px, 95vw);
+  padding: 2rem;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(0, 0, 0, 0.2));
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 24px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.app__header {
+  text-align: center;
+}
+
+.app__title {
+  margin: 0;
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  letter-spacing: 0.08em;
+}
+
+.app__subtitle {
+  margin: 0.25rem 0 0;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.95rem;
+}
+
+.slot {
+  display: grid;
+  gap: 1rem;
+}
+
+.slot__reels {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.reel {
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  padding: 1rem;
+  position: relative;
+  overflow: hidden;
+  min-height: 200px;
+}
+
+.reel::after {
+  content: '';
+  position: absolute;
+  inset: 50% 0 50%;
+  background: rgba(255, 255, 255, 0.15);
+  pointer-events: none;
+}
+
+.reel__window {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+  text-align: center;
+  font-size: 1.5rem;
+  letter-spacing: 0.08em;
+}
+
+.symbol {
+  padding: 0.6rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.slot__panel {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.panel__credits,
+.panel__bet {
+  padding: 0.75rem 1.5rem;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  min-width: 140px;
+  text-align: center;
+}
+
+.panel__label {
+  display: block;
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.panel__value {
+  font-size: 2rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.controls {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.button {
+  flex: 1;
+  min-width: 120px;
+  padding: 1rem;
+  font-size: 1.1rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  color: #05070f;
+}
+
+#bet-button {
+  background: linear-gradient(180deg, #fcb045, #fd1d1d);
+}
+
+#spin-button {
+  background: linear-gradient(180deg, #2bd2ff, #2bff88);
+}
+
+#reset-button {
+  background: linear-gradient(180deg, #ff5f6d, #ffc371);
+}
+
+.button:active {
+  transform: translateY(2px);
+  box-shadow: inset 0 4px 12px rgba(0, 0, 0, 0.35);
+}
+
+.log {
+  background: rgba(0, 0, 0, 0.55);
+  border-radius: 16px;
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.log__title {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+}
+
+.log__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  max-height: 160px;
+  overflow-y: auto;
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.log__item {
+  padding: 0.5rem 0.75rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+@media (max-width: 640px) {
+  .slot__reels {
+    grid-template-columns: repeat(3, minmax(0, 120px));
+    justify-content: center;
+  }
+
+  .controls {
+    flex-direction: column;
+  }
+
+  .button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- refactor the slot script into an ES module with a reusable `SlotMachine` class and improved bet/spin handling
- keep the HTML scaffold while switching to module loading for the browser entry point
- add a minimal Node-based test harness with DOM stubs to verify credits, bet logic, and log trimming

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d01cf976908329b900184d24498c7e